### PR TITLE
build: Simplify Linux Bazel build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,11 +24,11 @@ build:linux --copt='-Wno-missing-field-initializers' # Common idiom for zeroing 
 build:linux --cxxopt='-Wnon-virtual-dtor'
 build:linux --cxxopt='-Woverloaded-virtual'
 
-build:linux --per_file_copt='bench@-Wno-undef' # asio leaks this into our code.
+build:linux --per_file_copt='bench[:/]@-Wno-undef' # asio leaks this into our code.
 build:linux --per_file_copt='bench[:/]@-Wno-shadow' # asio leaks this into our code.
-build:linux --per_file_copt='example@-Wno-undef' # asio leaks this into our code.
+build:linux --per_file_copt='example[:/]@-Wno-undef' # asio leaks this into our code.
 build:linux --per_file_copt='example[:/]@-Wno-shadow' # asio leaks this into our code.
-build:linux --per_file_copt='natsuki@-Wno-undef' # asio leaks this into our code.
+build:linux --per_file_copt='natsuki[:/]@-Wno-undef' # asio leaks this into our code.
 build:linux --per_file_copt='natsuki[:/]@-Wno-shadow' # asio leaks this into our code.
 
 build:linux --per_file_copt='external/asio[:/]@-Wno-sign-compare'

--- a/.bazelrc
+++ b/.bazelrc
@@ -25,8 +25,11 @@ build:linux --cxxopt='-Wnon-virtual-dtor'
 build:linux --cxxopt='-Woverloaded-virtual'
 
 build:linux --per_file_copt='bench@-Wno-undef' # asio leaks this into our code.
+build:linux --per_file_copt='bench[:/]@-Wno-shadow' # asio leaks this into our code.
 build:linux --per_file_copt='example@-Wno-undef' # asio leaks this into our code.
+build:linux --per_file_copt='example[:/]@-Wno-shadow' # asio leaks this into our code.
 build:linux --per_file_copt='natsuki@-Wno-undef' # asio leaks this into our code.
+build:linux --per_file_copt='natsuki[:/]@-Wno-shadow' # asio leaks this into our code.
 
 build:linux --per_file_copt='external/asio[:/]@-Wno-sign-compare'
 build:linux --per_file_copt='external/asio[:/]@-Wno-undef'
@@ -34,10 +37,6 @@ build:linux --per_file_copt='external/boringssl[:/]@-Wno-pedantic'
 build:linux --per_file_copt='external/boringssl[:/]@-Wno-unused-parameter'
 
 build:gcc --per_file_copt='external/boringssl[:/]@-Wno-cast-function-type'
-
-build:clang --per_file_copt='bench[:/]@-Wno-shadow' # asio leaks this into our code.
-build:clang --per_file_copt='example[:/]@-Wno-shadow' # asio leaks this into our code.
-build:clang --per_file_copt='natsuki[:/]@-Wno-shadow' # asio leaks this into our code.
 
 build:windows --copt='/std:c++latest'
 build:windows --copt='/W4' # More warnings.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,14 +12,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: CC=clang-12 CXX=clang++-12 bazel build ... --config clang
+      run: CC=clang-12 CXX=clang++-12 bazel build ...
 
   linux-clang-asan:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: CC=clang-12 CXX=clang++-12 bazel build ... --config clang --config asan
+      run: CC=clang-12 CXX=clang++-12 bazel build ... --config asan
 
   windows-msvc:
     runs-on: windows-2022


### PR DESCRIPTION
gcc supports Wshadow, so no need to have a separate build configuration
for Clang.

Clang only supports Wcast-function-type starting with Clang 13, so we
still need a separate configuration for gcc for now.