### PR TITLE
bench: Give the plain-text-result printer a better name

### DIFF
--- a/bench/BUILD
+++ b/bench/BUILD
@@ -31,8 +31,8 @@ cc_library(
 )
 
 cc_library(
-    name = "stdout_listener",
-    hdrs = ["stdout_listener.h"],
+    name = "plain_text_reporter",
+    hdrs = ["plain_text_reporter.h"],
     visibility = ["//visibility:public"],
     deps = [":ibenchmark_listener"],
 )
@@ -90,7 +90,7 @@ cc_binary(
         ":arg_parser",
         ":lib",
         ":natsuki_pubsub",
-        ":stdout_listener",
+        ":plain_text_reporter",
         "//natsuki",
     ],
 )

--- a/bench/main.cc
+++ b/bench/main.cc
@@ -7,7 +7,7 @@
 #include "bench/natsuki_publisher.h"
 #include "bench/natsuki_subscriber.h"
 #include "bench/options.h"
-#include "bench/stdout_listener.h"
+#include "bench/plain_text_reporter.h"
 
 #include <exception>
 #include <iostream>
@@ -25,7 +25,7 @@ int main(int argc, char **argv) try {
             .positional(opts.address)
             .parse(argc, argv);
 
-    bench::StdoutListener listener{};
+    bench::PlainTextReporter listener{};
     bench::NatsukiPublisherFactory pub_factory{};
     bench::NatsukiSubscriberFactory sub_factory{};
     bench::run_bench(listener, std::move(opts), pub_factory, sub_factory);

--- a/bench/plain_text_reporter.h
+++ b/bench/plain_text_reporter.h
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
-#ifndef NATSUKI_BENCH_STDOUT_LISTENER_H_
-#define NATSUKI_BENCH_STDOUT_LISTENER_H_
+#ifndef NATSUKI_BENCH_PLAIN_TEXT_REPORTER_H_
+#define NATSUKI_BENCH_PLAIN_TEXT_REPORTER_H_
 
 #include "bench/ibenchmark_listener.h"
 
@@ -14,7 +14,7 @@
 
 namespace bench {
 
-class StdoutListener final : public IBenchmarkListener {
+class PlainTextReporter final : public IBenchmarkListener {
 public:
     void on_benchmark_start(Options const &opts) override {
         opts_ = opts;


### PR DESCRIPTION
This is in preparation of adding a JSON reporter.