### PR TITLE
bench: Split PartialResult into {Subscribe,Publish}Result

### DIFF
--- a/bench/BUILD
+++ b/bench/BUILD
@@ -14,8 +14,14 @@ cc_library(
 )
 
 cc_library(
-    name = "partial_result",
-    hdrs = ["partial_result.h"],
+    name = "publish_result",
+    hdrs = ["publish_result.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "subscribe_result",
+    hdrs = ["subscribe_result.h"],
     visibility = ["//visibility:public"],
 )
 
@@ -26,7 +32,8 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":options",
-        ":partial_result",
+        ":publish_result",
+        ":subscribe_result",
     ],
 )
 
@@ -83,8 +90,9 @@ cc_library(
     deps = [
         ":ibenchmark_listener",
         ":options",
-        ":partial_result",
+        ":publish_result",
         ":pubsub_interface",
+        ":subscribe_result",
     ],
 )
 

--- a/bench/bench.cc
+++ b/bench/bench.cc
@@ -8,7 +8,8 @@
 #include "bench/ipublisher.h"
 #include "bench/isubscriber.h"
 #include "bench/options.h"
-#include "bench/partial_result.h"
+#include "bench/publish_result.h"
+#include "bench/subscribe_result.h"
 
 #include <algorithm>
 #include <chrono>
@@ -56,7 +57,7 @@ void run_bench(
     listener.on_benchmark_start(opts);
 
     std::vector<std::unique_ptr<ISubscriber>> subscribers;
-    std::vector<PartialResult> subscriber_results(opts.subscriber_count);
+    std::vector<SubscribeResult> subscriber_results(opts.subscriber_count);
 
     listener.before_subscriber_start();
     for (int i = 0; i < opts.subscriber_count; ++i) {
@@ -99,7 +100,7 @@ void run_bench(
     }
 
     auto const start = std::chrono::high_resolution_clock::now();
-    std::vector<std::future<PartialResult>> runners;
+    std::vector<std::future<PublishResult>> runners;
     runners.reserve(opts.publisher_count);
     for (auto &publisher : publishers) {
         runners.push_back(std::async(std::launch::async, [&] {
@@ -112,7 +113,7 @@ void run_bench(
 
             auto const my_end = std::chrono::high_resolution_clock::now();
 
-            return PartialResult{
+            return PublishResult{
                 .start_time = my_start,
                 .end_time = my_end,
                 .messages = my_msgs,
@@ -139,7 +140,7 @@ void run_bench(
         publishers.pop_back();
     }
 
-    std::vector<PartialResult> publisher_results{};
+    std::vector<PublishResult> publisher_results{};
     publisher_results.reserve(runners.size());
     std::transform(
             runners.begin(), runners.end(), std::back_inserter(publisher_results),

--- a/bench/ibenchmark_listener.h
+++ b/bench/ibenchmark_listener.h
@@ -6,7 +6,8 @@
 #define NATSUKI_BENCH_BENCHMARK_LISTENER_H_
 
 #include "bench/options.h"
-#include "bench/partial_result.h"
+#include "bench/publish_result.h"
+#include "bench/subscribe_result.h"
 
 #include <chrono>
 #include <vector>
@@ -19,8 +20,8 @@ public:
     virtual void on_benchmark_start(Options const &) = 0;
     virtual void before_subscriber_start() = 0;
     virtual void before_publisher_start() = 0;
-    virtual void on_publish_done(std::vector<PartialResult> const &) = 0;
-    virtual void on_subscribe_done(std::vector<PartialResult> const &) = 0;
+    virtual void on_publish_done(std::vector<PublishResult> const &) = 0;
+    virtual void on_subscribe_done(std::vector<SubscribeResult> const &) = 0;
     virtual void on_benchmark_done(std::chrono::milliseconds duration) = 0;
 };
 

--- a/bench/json_reporter.h
+++ b/bench/json_reporter.h
@@ -33,7 +33,7 @@ public:
     void before_subscriber_start() override {}
     void before_publisher_start() override {}
 
-    void on_publish_done(std::vector<PartialResult> const &results) override {
+    void on_publish_done(std::vector<PublishResult> const &results) override {
         ss_ << "\"publish_results\":" << '[';
         for (std::size_t i = 0; i < results.size(); ++i) {
             if (i > 0) {
@@ -45,7 +45,7 @@ public:
         ss_ << "],";
     }
 
-    void on_subscribe_done(std::vector<PartialResult> const &results) override {
+    void on_subscribe_done(std::vector<SubscribeResult> const &results) override {
         ss_ << "\"subscribe_results\":" << '[';
         for (std::size_t i = 0; i < results.size(); ++i) {
             if (i > 0) {
@@ -63,7 +63,13 @@ public:
     }
 
 private:
-    void to_json(std::ostream &os, PartialResult const &res) {
+    void to_json(std::ostream &os, PublishResult const &res) {
+        os << "{\"start_time\":" << res.start_time.time_since_epoch().count() << ','
+                << "\"end_time\":" << res.end_time.time_since_epoch().count() << ','
+                << "\"messages\":" << res.messages << '}';
+    }
+
+    void to_json(std::ostream &os, SubscribeResult const &res) {
         os << "{\"start_time\":" << res.start_time.time_since_epoch().count() << ','
                 << "\"end_time\":" << res.end_time.time_since_epoch().count() << ','
                 << "\"messages\":" << res.messages << '}';

--- a/bench/plain_text_reporter.h
+++ b/bench/plain_text_reporter.h
@@ -41,7 +41,7 @@ public:
                 << opts_.messages / opts_.publisher_count << " messages each.\n";
     }
 
-    void on_publish_done(std::vector<PartialResult> const &results) override {
+    void on_publish_done(std::vector<PublishResult> const &results) override {
         for (std::size_t i = 0; i < results.size(); ++i) {
             auto const res = results[i];
             auto const duration = std::chrono::duration_cast<std::chrono::milliseconds>(res.end_time - res.start_time);
@@ -52,7 +52,7 @@ public:
         }
     }
 
-    void on_subscribe_done(std::vector<PartialResult> const &results) override {
+    void on_subscribe_done(std::vector<SubscribeResult> const &results) override {
         for (int i = 0; i < opts_.subscriber_count; ++i) {
             auto const res = results[i];
             auto const duration = std::chrono::duration_cast<std::chrono::milliseconds>(res.end_time - res.start_time);

--- a/bench/publish_result.h
+++ b/bench/publish_result.h
@@ -2,14 +2,14 @@
 //
 // SPDX-License-Identifier: MIT
 
-#ifndef NATSUKI_BENCH_PARTIAL_RESULT_H_
-#define NATSUKI_BENCH_PARTIAL_RESULT_H_
+#ifndef NATSUKI_BENCH_PUBLISH_RESULT_H_
+#define NATSUKI_BENCH_PUBLISH_RESULT_H_
 
 #include <chrono>
 
 namespace bench {
 
-struct PartialResult {
+struct PublishResult {
     std::chrono::time_point<std::chrono::high_resolution_clock> start_time;
     std::chrono::time_point<std::chrono::high_resolution_clock> end_time;
     int messages;

--- a/bench/subscribe_result.h
+++ b/bench/subscribe_result.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2022 Robin Lindén <dev@robinlinden.eu>
+//
+// SPDX-License-Identifier: MIT
+
+#ifndef NATSUKI_BENCH_SUBSCRIBE_RESULT_H_
+#define NATSUKI_BENCH_SUBSCRIBE_RESULT_H_
+
+#include <chrono>
+
+namespace bench {
+
+struct SubscribeResult {
+    std::chrono::time_point<std::chrono::high_resolution_clock> start_time;
+    std::chrono::time_point<std::chrono::high_resolution_clock> end_time;
+    int messages;
+};
+
+} // namespace bench
+
+#endif


### PR DESCRIPTION
While they're identical right now, the SubscribeResult will soon also
contain latency information.