### PR TITLE
build: Disallow empty globs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,12 @@
 build --enable_platform_specific_config
 test --test_output=errors
 
+# Bazel deprecations
+# =========================================================
+# See: https://docs.bazel.build/versions/main/backward-compatibility.html
+
+build --incompatible_disallow_empty_glob
+
 # Compiler configuration
 # =========================================================
 


### PR DESCRIPTION
This makes porting dependencies to Bazel less error-prone.