### PR TITLE
deps: Don't pull in boringssl

### DIFF
--- a/third_party/asio.BUILD
+++ b/third_party/asio.BUILD
@@ -2,7 +2,10 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "asio",
-    srcs = glob(["src/*.cpp"]),
+    srcs = [
+        "src/asio.cpp",
+        # "src/asio_ssl.cpp",
+    ],
     hdrs = glob([
         "include/**/*.hpp",
         "include/**/*.ipp",
@@ -11,7 +14,7 @@ cc_library(
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
     deps = [
-        "@boringssl//:ssl",
+        # "@boringssl//:ssl",
         "@pthread",
     ],
 )


### PR DESCRIPTION
We don't yet support TLS in //natsuki, so boringssl is currently unused,
so no point in building it for now. I'm keeping the preparation for it
as I am planning on supporting TLS in //natsuki.