### PR TITLE
ci: Get rid of superfluous names for CI steps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,8 +48,7 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v3
-      - name: Build
-        run: bazel build ...
+      - run: bazel build ...
       - run: |
           curl --location https://github.com/nats-io/nats-server/releases/download/$NATS_VERSION/nats-server-$NATS_VERSION-windows-amd64.tar.gz | tar -xvz
           ./nats-server-$NATS_VERSION-windows-amd64/nats-server --debug >>nats.log 2>&1 &
@@ -62,12 +61,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: Install
-        run: |
-          wget --output-document=buildifier https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-amd64
-          sudo chmod +x buildifier
-      - name: Check
-        run: ./buildifier --lint=warn --warnings=all -mode diff WORKSPACE $(find . -type f -iname "*.BUILD" -or -iname BUILD)
+      - run: wget --output-document=buildifier https://github.com/bazelbuild/buildtools/releases/download/5.1.0/buildifier-linux-amd64 && sudo chmod +x buildifier
+      - run: ./buildifier --lint=warn --warnings=all -mode diff WORKSPACE $(find . -type f -iname "*.BUILD" -or -iname BUILD)
 
   prettier:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
The commands themselves are trivial and I prefer seeing that rather than
the name.